### PR TITLE
Add FEATURES="buildpkg" to get backups of installed packages

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -159,7 +159,7 @@ echo $MAKECONF
 echo >> $MAKECONF
 echo "# add valid -march= to CFLAGS" >> $MAKECONF
 echo "MAKEOPTS=\"-j$(nproc)\"" >> $MAKECONF
-echo "FEATURES=\"parallel-fetch\"" >> $MAKECONF
+echo "FEATURES=\"parallel-fetch buildpkg\"" >> $MAKECONF
 # tty-helpers is needed py apcupsd
 echo "USE=\"\${USE} -X -bindist python qemu gnutls idn iproute2 logrotate snmp tty-helpers\"" >> $MAKECONF
 


### PR DESCRIPTION
This could really save your a** if you do a upgrade and something breaks since it makes it possible to roll back.
See https://wiki.gentoo.org/wiki/Binary_package_guide
Fixes #29